### PR TITLE
GSequencer v3.2.13

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -500,8 +500,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.2.x/gsequencer-3.2.10.tar.gz",
-                    "sha256": "38ded28222945595c12100c5e6207372294a131c8397240e3ce5255a3ed2e5d4"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.2.x/gsequencer-3.2.13.tar.gz",
+                    "sha256": "842f2bd2b9686fb077d8092d6395ba2a569e3919d0bf9d50f8fe4d97ed6c0de5"
 
                 },
                 {


### PR DESCRIPTION
* fixed greedy ags-lv2 and ags-dssi recall
