### PR TITLE
Add support for Audio plugins

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -20,10 +20,36 @@
         "--filesystem=host",
         "--env=AGS_LICENSE_FILENAME=/app/share/gsequencer/GPL-3",
         "--env=AGS_ONLINE_HELP_START_FILENAME=file:///app/share/doc/gsequencer/html/index.html",
-        "--env=LADSPA_PATH=/app/lib/ladspa",
-        "--env=DSSI_PATH=/app/lib/dssi",
-        "--env=LV2_PATH=/app/lib/lv2"
+        "--env=LADSPA_PATH=/app/extensions/LadspaPlugins/ladspa:/app/lib/ladspa",
+        "--env=DSSI_PATH=/app/extensions/DssiPlugins/dssi:/app/lib/dssi",
+        "--env=LV2_PATH=/app/extensions/Lv2Plugins/lv2:/app/lib/lv2"
     ],
+    "add-extensions": {
+        "org.freedesktop.LinuxAudio.Lv2Plugins": {
+            "directory": "extensions/Lv2Plugins",
+            "version": "19.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "lv2",
+            "subdirectories": true,
+            "no-autodownload": true
+        },
+        "org.freedesktop.LinuxAudio.DssiPlugins": {
+            "directory": "extensions/DssiPlugins",
+            "version": "19.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "dssi",
+            "subdirectories": true,
+            "no-autodownload": true
+        },
+        "org.freedesktop.LinuxAudio.LadspaPlugins": {
+            "directory": "extensions",
+            "version": "19.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "ladspa",
+            "subdirectories": true,
+            "no-autodownload": true
+        }
+    },
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
@@ -161,7 +187,10 @@
                 "make html",
                 "make install-html-mkdir",
                 "make install-html",
-                "sed -i -e 's~Icon=/app/share/gsequencer/icons/ags.png~Icon=org.nongnu.gsequencer.gsequencer.png~g' /app/share/applications/gsequencer.desktop"
+                "sed -i -e 's~Icon=/app/share/gsequencer/icons/ags.png~Icon=org.nongnu.gsequencer.gsequencer.png~g' /app/share/applications/gsequencer.desktop",
+                "install -d /app/extensions/Lv2Plugins",
+                "install -d /app/extensions/LadspaPlugins",
+                "install -d /app/extensions/DssiPlugins"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This add support for Linux Audio plugins: LADSPA, LV2, and DSSI.

Currently waiting to land are swh flathub/flathub#1504 and SoSynth flathub/flathub#1459

Many more in the queue.

When CMT lands, it can be removed from this build and tell to install the plugins as a flatpak automatically (I'll submit a PR in time).

Note: I did not add VST and VST3 support. But it is possible too.