### PR TITLE
new upstream v3.3.2

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -195,8 +195,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.3.x/gsequencer-3.3.1.tar.gz",
-                    "sha256": "b8bdd320aaff1f5de914e5d057b547937b751c78b8e85d464be165383330171b"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.3.x/gsequencer-3.3.2.tar.gz",
+                    "sha256": "fa003643c31eedcedb5b6a32a76bb0df3e0ebf950a0cfdd1633713f13e389446"
 
                 },
                 {


### PR DESCRIPTION
* fixed potential dead-lock of ags-fx-ladspa and ags-fx-lv2
* fixed missing reverse mapping
* fixed missing AgsBulkMember ports
