### PR TITLE
Update runtime to GNOME 3.38

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.nongnu.gsequencer.gsequencer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "gsequencer",
     "rename-desktop-file": "gsequencer.desktop",
@@ -27,7 +27,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "19.08",
+            "version": "20.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa;dssi;lv2",
             "subdirectories": true,
@@ -35,7 +35,7 @@
         },
         "org.freedesktop.LinuxAudio.Plugins.CMT": {
             "directory": "extensions/Plugins/CMT",
-            "version": "19.08",
+            "version": "20.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa",
             "autodelete": false,


### PR DESCRIPTION
Also update shared modules.

From here, it is possible to support JACK through Pipewire