### PR TITLE
Add jack support via Pipewire

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.nongnu.gsequencer.gsequencer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "gsequencer",
     "rename-desktop-file": "gsequencer.desktop",
@@ -16,6 +16,9 @@
         "--socket=pulseaudio",
         /* Soundcard and MIDI */
         "--device=all",
+        /* For pipewire + JACK */
+        "--filesystem=xdg-run/pipewire-0",
+        "--system-talk-name=org.freedesktop.RealtimeKit1",
         /* Allow loading, saving files from anywhere (portals don’t work yet) */
         "--filesystem=host",
         "--env=AGS_LICENSE_FILENAME=/app/share/gsequencer/GPL-3",
@@ -43,6 +46,7 @@
         }
     },
     "cleanup": [
+        "/bin/jack*",
         "/include",
         "/lib/pkgconfig",
         "/share/man",


### PR DESCRIPTION
This should allow JACK to work. Previously it would never.

Also updated the runtime to GNOME 40 and the shared-modules.