### PR TITLE
new upstream v3.15.2

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -217,8 +217,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.14.x/gsequencer-3.14.11.tar.gz",
-                    "sha256": "a93238ea1954a72e9fa2dd6ac4c1807155da1be0b3bbe24423c176543366f9ec"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/3.15.x/gsequencer-3.15.2.tar.gz",
+                    "sha256": "fcd49b63e84cbee32445059892d5efb27208fd6fa7fe3f2ece8ecfc8d349df49"
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
*  fixed missing configure_event callback to reset scrollbars of composite edit
