### PR TITLE
new upstream Advanced Gtk+ Sequencer 6.3.1

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -259,8 +259,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.2.x/gsequencer-6.2.5.tar.gz",
-                    "sha256": "5363bcb6e9cd5556f788b92a49f097e2eb5c43d7ade12a981b7d85dd551a4728"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.3.x/gsequencer-6.3.1.tar.gz",
+                    "sha256": "01c7587a78e4d8ec656d4bd9f4595129621e71cef8fa028bb0b9aca5aaa3201d"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
* implemented note 256th attack of 16th pulse
* refactored ags-fx-notation
* refactored all soundcard implementations
