### PR TITLE
Advanced Gtk+ Sequencer v6.15.4

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -260,8 +260,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.15.x/gsequencer-6.15.3.tar.gz",
-                    "sha256": "142124f899532ceb178a43c7a55f6b1418f93460adf54bf848cbeca5bf1b8bdc"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.15.x/gsequencer-6.15.4.tar.gz",
+                    "sha256": "96a4621db9ddd40981246c2c2de4c326827b39b92364d81d9fd4a837e14d272a"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
* improved open file, missing plugin caused SIGSEGV
* improved notation edit missing note 256th support caused corrupted notation while keyboard editing

