### PR TITLE
new upstream Advanced Gtk+ Sequencer version 6.16.3

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -260,8 +260,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.16.x/gsequencer-6.16.2.tar.gz",
-                    "sha256": "97c8738b5e591b893388613de8c109278e9ea3b53a12886ab76e5f847f7c224e"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/6.16.x/gsequencer-6.16.3.tar.gz",
+                    "sha256": "c76db4b3902b3125dbcaf7559f1ad6610647dc9fa68e1145447dd9ee74999cc1"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
* fixed potential buffer overflow with new pitch utility functions
