### PR TITLE
Advanced Gtk+ Sequencer new upstream version 8.1.1

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -260,8 +260,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/8.0.x/gsequencer-8.0.14.tar.gz",
-                    "sha256": "15958a7482d06bcf799438cad08c36c113521b5a6bdbcaf1428802b902c5e1cc"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/gsequencer/8.1.x/gsequencer-8.1.1.tar.gz",
+                    "sha256": "915f170a60a69ecd140d59931cab14e4b750554461f9f5476fb73cd935803ff3"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
* fixed potential SIGSEGV of composite editor popovers
* fixed automation editor restore from XML project files
