### PR TITLE
Update runtime to GNOME 50

### DIFF
--- a/org.nongnu.gsequencer.gsequencer.json
+++ b/org.nongnu.gsequencer.gsequencer.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.nongnu.gsequencer.gsequencer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "gsequencer",
     "rename-desktop-file": "gsequencer.desktop",
@@ -9,16 +9,11 @@
     "rename-appdata-file": "org.nongnu.gsequencer.gsequencer.appdata.xml",
     "rename-icon": "gsequencer",
     "finish-args": [
-        /* X11 + XShm access */
         "--share=ipc",
         "--socket=x11",
-        /* Note playback */
         "--socket=pulseaudio",
-        /* Soundcard and MIDI */
-        "--device=all",
-        /* For pipewire + JACK */
+        "--device=dri",
         "--filesystem=xdg-run/pipewire-0:ro",
-        /* Allow loading, saving files from anywhere (portals don’t work yet) */
         "--filesystem=host",
         "--env=AGS_LICENSE_FILENAME=/app/share/gsequencer/GPL-3",
         "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa:/app/lib/ladspa",
@@ -51,7 +46,8 @@
         "/share/gtk-doc",
         "/include/vst3",
         "/lib/vst3",
-        "*.la"
+        "*.la",
+        "*.a"
     ],
     "modules": [
         "shared-modules/gtk2/gtk2.json",


### PR DESCRIPTION
- Update fluidsynth via shared-modules
- Cleanup *.a to reduce package size
- Remove JSON comments as they will no longer be allowed



This fixes the build warnings ignored on https://github.com/flathub/org.nongnu.gsequencer.gsequencer/pull/316#issuecomment-4914832450